### PR TITLE
Editorial fixes to D0197R0

### DIFF
--- a/doc/proposal/reflection/P0197R0.md
+++ b/doc/proposal/reflection/P0197R0.md
@@ -21,14 +21,15 @@
     </tr>
 </table>
 
-# Default Tuple-like access 
+
+# Default Tuple-like Access
 ===========================
 
 **Abstract**
 
-Defining tuple-like access `tuple_size`, `tuple_element` and `get<I>/get<T>` as comparison operators,  as proposed in [N4475], for simple classes is tedious, repetitive, slightly error-prone, and easily automated. 
+Defining tuple-like access `tuple_size`, `tuple_element` and `get<I>/get<T>` for simple classes is -- as for comparison operators ([N4475]) -- tedious, repetitive, slightly error-prone, and easily automated.
 
-I propose to (implicitly) supply default version of this operation and traits, if needed. The meaning `get<I>` is to return a reference to the I<sup>th</sup> member. 
+I propose to (implicitly) supply default versions of these operation and traits, if needed. The meaning of `get<I>` is to return a reference to the I<sup>th</sup> member.
 
 # Table of Contents
 
@@ -45,49 +46,49 @@ I propose to (implicitly) supply default version of this operation and traits, i
 
 # Introduction
 
-Defining tuple-like access `tuple_size`, `tuple_element` and `get<I>/get<T>`, as defining comparison operators as proposed in [N4475], for simple classes is tedious, repetitive, slightly error-prone, and easily automated. 
+Defining tuple-like access `tuple_size`, `tuple_element` and `get<I>/get<T>` for simple classes is -- as for comparison operators ([N4475]) -- tedious, repetitive, slightly error-prone, and easily automated.
 
-I propose to (implicitly) supply default version of this operation and traits, if needed. The meaning `get<I>` is to return a reference to the I<sup>th</sup> member. 
+I propose to (implicitly) supply default versions of these operation and traits, if needed. The meaning of `get<I>` is to return a reference to the I<sup>th</sup> member.
 
-If the simple defaults are unsuitable for a class, a programmer can, as ever, define more suitable ones or suppress the defaults. The proposal is to add the operations as an integral part of C++ (like =), rather than as a library feature. 
+If the simple defaults are unsuitable for a class, a programmer can, as ever, define more suitable ones or suppress the defaults. The proposal is to add the operations as an integral part of C++ (like the assignment operator), rather than as a library feature.
 
-The proposal follows the same approach as Default comparison as in [N4475], that is, that having default generated code for these basic operations only when needed and possible would make the language simpler. 
+The proposal follows the same approach as Default Comparison ([N4475]), that is, that having default generated code for these basic operations only when needed and possible would make the language simpler.
 
-The concerned classes would be the same as the one on which Structural Binding [P0144R0] can be applied.
+The concerned classes would be the same as the ones on which Structured Binding ([P0144R0]) can be applied.
 
 This paper contains no proposed wording. This is a discussion paper to determine EWG interest in the feature, and if there is interest to get direction for a follow-up paper with wording.
 
 # Motivation
 
-Algorithms as `std::tuple_cat` and `std::experimental::apply` work as well with tuple-like types. There are many more of them, a lot of the homogeneous container algorithm are applicable to heterogeneous containers and functions, see [Boost.Fusion] and [Boost.Hana]. Some examples os such algorithms are  `fold`, `accumulate`, `for_each` `any_of`,  `all_of`, `none_of`, `find`, `count`, `filter`, `transform`, `replace`, `join`, `zip`, `flatten`.
+Algorithms such as `std::tuple_cat` and `std::experimental::apply` work as well with tuple-like types. There are many more of them; a lot of the homogeneous container algorithm are applicable to heterogeneous containers and functions, see [Boost.Fusion] and [Boost.Hana]. Some examples of such algorithms are  `fold`, `accumulate`, `for_each` `any_of`,  `all_of`, `none_of`, `find`, `count`, `filter`, `transform`, `replace`, `join`, `zip`, `flatten`.
 
-Beside `std::pair`, `std::tuple` and `std::array` we have that in particular aggregates are good candidate to be considered as tuple-like types. However defining the tuple-like access functions is tedious, repetitive, slightly error-prone, and easily automated. 
+Besides `std::pair`, `std::tuple` and `std::array`, aggregates in particular are good candidates to be considered as tuple-like types. However defining the tuple-like access functions is tedious, repetitive, slightly error-prone, and easily automated.
 
-Some libraries, in particular [Boost.Fusion] and [Boost.Hana] provide some macros to generate the needed reflection instantiations. Once this reflection is available for a type, the user can use the struct on  algorithm working with heterogeneous sequences. Very often, when macros are used for something, it is hiding a language feature.
+Some libraries, in particular [Boost.Fusion] and [Boost.Hana] provide some macros to generate the needed reflection instantiations. Once this reflection is available for a type, the user can use the struct in  algorithms working with heterogeneous sequences. Very often, when macros are used for something, it is hiding a language feature.
 
-Proposals such as Structural binding [P0144R0] (or its competitor [P0151R0]) would provide already a positional access. This proposal and structural binding should use the same restrictions on the types that can be applied.
+Proposals such as Structured Bindings [P0144R0] (or its competitor [P0151R0]) would already provide positional access. This proposal and structured binding should use the same restrictions on the types that can be applied.
 
 # Proposal
 
-I propose to generate default versions for `tuple_size`, `tuple_element` and `get<I>/get<T>` when needed. If those defaults are unsuitable for a type, `=delete` them. If non-default of those operations are needed, define them (as always). If an operation is already declared, a default is not generated for it. This is exactly the way assignment and constructors work today and as comparison operators would work is [N4475] is adopted.
+I propose to generate default implementations for `tuple_size`, `tuple_element` and `get<I>/get<T>` when needed. If the defaults are unsuitable for a type, the user may be explicitly delete (`=delete`) them. If the default implementation is not suitable, the user may provide a definition (as always). If an operation is already declared, a default implementation is not generated for it. This is exactly the way assignment and constructors work today and as comparison operators would work if [N4475] is adopted.
 
 A library solution could be an alternative once we have the necessary reflection traits.
 
 ## Common restrictions
 
-A default implementation of the tuple-like access for objects of a class can be generated unless the class
+A default implementation of tuple-like access for a class can be generated unless the class
 
 * contains protected or private non-static data members, or
 * contains protected or private or virtual base classes, or
-* contains a public base class that fulfills some of these restrictions. 
- 
-We expect that a follow-up for [P0144R0] will define the same restrictions but we are not sure the first version would allow inheritance.
+* contains a public base class that fulfills some of these restrictions.
+
+We expect that a follow-up for [P0144R0] will define the same restrictions but we are not sure the first version would allow inheritance.
 
 ## Tuple-like access
 
-Given a class `C` that doesn't define the tuple-like access `get<I>` and it is not restricted by the previous conditions, let 
+Given a class `C` that doesn't define the tuple-like access `get<I>` and it is not restricted by the previous conditions, let
 
-* `N` be the number of public non static data members,
+* `N` be the number of public non-static data members,
 * `Ti` the type of the i<sup>th</sup> data member (0 based).
 
 The following could be defined
@@ -95,42 +96,42 @@ The following could be defined
 ```c++
 namespace std {
     template <>
-      struct tuple_size<C> : integral_constant<size_t, N> {}    
+      struct tuple_size<C> : integral_constant<size_t, N> {}
     template <>
       struct tuple_element<i, C> { using type = Ti; }    // for i in 0..N-1
-      
+
     template <size_t I>
-      constexpr tuple_element_t<I, C>& get(C& c) noexcept;    
+      constexpr tuple_element_t<I, C>& get(C& c) noexcept;
     template <size_t I>
-      constexpr tuple_element_t<I, C> const& get(C const& c) noexcept;    
+      constexpr tuple_element_t<I, C> const& get(C const& c) noexcept;
     template <size_t I>
-      constexpr tuple_element_t<I, C> && get(C && c) noexcept;    
-    
+      constexpr tuple_element_t<I, C> && get(C && c) noexcept;
+
     template <class T>
-      constexpr T& get(C& c) noexcept;    
+      constexpr T& get(C& c) noexcept;
     template <class T>
-      constexpr T const& get(C const& c) noexcept;    
+      constexpr T const& get(C const& c) noexcept;
     template <class T>
-      constexpr T && get(C && c) noexcept;    
+      constexpr T && get(C && c) noexcept;
 }
 ```
 
 
-This definition would be in line with the tuple-like access as defined for `std::tuple`. 
+This definition would be in line with the tuple-like access as defined for `std::tuple`.
 
 ## Explicit conversion to `std::pair<T,U>` and `std::tuple<Ts...>`
 
-We could make any class `C` satisfying the constraints and having 2 data members having types `T` and `U` to be explicitly convertible to `std::pair<T,U>`.
+We could make any class `C` satisfying the constraints and having 2 data members of types `T` and `U` to be explicitly convertible to `std::pair<T,U>`.
 
-We could make any class `C` satisfying the constraints and having `N` data members having types `T1` ... `Tn` explicitly convertible to `std::tuple<T1,..., Tn>`.
+We could make any class `C` satisfying the constraints and having `N` data members of types `T1` ... `Tn` explicitly convertible to `std::tuple<T1,..., Tn>`.
 
 We could generate the explicit conversions  `operator std::pair<T,U>` and `operator std::tuple<Ts...>`. However the syntax is not friendly. Instead we propose to overload the new `to_pair` and `to_tuple` functions in the namespace of the class `C`.
 
 ```c++
 namespace Cns {
-    class C; 
-    auto to_pair(C const&); 
-    auto to_tuple(C const&); 
+    class C;
+    auto to_pair(C const&);
+    auto to_tuple(C const&);
 }
 ```
 
@@ -145,29 +146,29 @@ The definition of the tuple-like access could be removed in the text of the stan
 
 ## What about inheritance?
 
-With the adoption of Extension to aggregate initialization [P0017R0], it is coherent to permit public inheritance as we want the tuple-like access to be generated for aggregates.
+With the adoption of Extension to Aggregate Initialization [P0017R0], it is coherent to permit public inheritance as we want the tuple-like access to be generated for aggregates.
 
 ## Do we want to consider base classes or its data members as elements of the tuple-like class ?
 
-[P0017R0] considers the base classes as element of the aggregation. 
+[P0017R0] considers the base classes as element of the aggregation.
 
-We don't know yet what Structured bindings [P0144R0] but suspect that it would consider base classes as elements of the structure binding.
+We don't know yet what Structured Bindings [P0144R0] will do, but suspect that it would consider base classes as elements of the structured binding.
 
-The tuple-like access to `std::tuple` is member oriented even if the order is not required. Having coherent order of members and template parameters could permit to convert from a tuple to a tuple having some of the last members removed.
+The tuple-like access to `std::tuple` is member oriented even if the order is not required. Having coherent order of members and template parameters could permit conversion from a tuple to a tuple having some of the last members removed.
 
-This is why this proposal give recursive access to the member of the base classes.
+This is why this proposal gives recursive access to the member of the base classes.
 
 ## Do we need conversions
 
-We can consider `std::tuple` as the underlaying type of such structures. It seems reasonable to have a conversion to it. 
+We can consider `std::tuple` as the underlying type of such structures. It seems reasonable to have a conversion to it.
 
 Having this conversion will allow the user to use functions that work with `std::tuple`.
- 
+
 ## Why not implicit conversions?
 
-So what kind of conversions are desired? `std``tuple<T,U>` is implicitly convertible to `std::pair<T,U>`. 
+So what kind of conversions are desired? `std``tuple<T,U>` is implicitly convertible to `std::pair<T,U>`.
 
-Note that the cost of the conversion means a copy and that this is more expensive. The cost of copying  two elements could be less expensive than copying more. 
+Note that the cost of the conversion means a copy and that this is more expensive. The cost of copying  two elements could be less expensive than copying more.
 
 ## Why not explicit conversion operator?
 
@@ -175,11 +176,11 @@ We could generate also the explicit conversion operator, but the syntax is less 
 
 # Working paper wording
 
-This wording is very “drafty” and has not gone through expert review. It is intended to reflect the design decisions described above. 
+This wording is very “drafty” and has not gone through expert review. It is intended to reflect the design decisions described above.
 
-The author was not aware of the new wording for Default comparison in [N4532]. There are a lot of there that should inspire the wording for this function.
+The author was not aware of the new wording for Default Comparison in [N4532]. There is a lot there that should inspire the wording for this function.
 
-The wording that follows is based on the wording of the current standard in particular [N4527] and in initial wording in [N4475].
+The wording that follows is based on the wording of the current standard in particular ([N4527]), and on initial wording in [N4475].
 
 ## Tuple-like access expression [expr.get]
 
@@ -188,24 +189,24 @@ A *tuple-like access expression* is a particular case of a *function call expres
 If an operand is of class type and no suitable function is found in the class namespace, the implicitly-declared `get<I>` non-member operation as described in [over.generate_get] (if any) is used.
 
 
-**Add a Special non-member tuple-like access operations section after 13.6**
+**Add a "Special non-member tuple-like access operations" section after 13.6**
 
 ## Special non-member `get` operation  [over.generate_get]
 
 ### Implicitly-declared `get` non-member operation
 
-If no user-defined `get` operation is provided for a class type `T` (`struct`, `class` but not `union`), and all of the following is true: 
+If no user-defined `get` operation is provided for a class type `T` (`struct`, `class` but not `union`), and all of the following is true:
 
 * doesn't contain protected or private non-static data members, or
 * doesn't contain protected or private or virtual base classes, or
-* doesn't contain a public base class that fulfills some of these restrictions. 
+* doesn't contain a public base class that fulfills some of these restrictions.
 
 
-then the compiler will declare a `get` operation with the signature 
+then the compiler will declare a `get` operation with the signature
 
 ```c++
 template <size_t I>
-requires I < tuple_size<T>{}  
+requires I < tuple_size<T>{}
 friend tuple_element<T, I> get(T&) noexcept(see below);
 ```
 
@@ -214,11 +215,11 @@ The generated implementation is not considered a function so it cannot have its 
 
 ### Explicitly defaulted `get` non-member operation
 
-The user cannot force the generation of the implicitly declared `get ` operation declaring it with the keyword `default`. 
+The user cannot force the generation of the implicitly declared `get ` operation declaring it with the keyword `default`.
 
 ### Deleted implicitly-declared `get` non-member operation
 
-The implicitly-declared or defaulted `get` operation for class `T` is defined as deleted in any of the following is true: 
+The implicitly-declared or defaulted `get` operation for class `T` is defined as deleted if any of the following is true:
 
 * ???;
 
@@ -226,13 +227,13 @@ The deleted implicitly-declared `get` operation is ignored by overload resolutio
 
 ### Implicitly-defined `get` non-member operation
 
-If the implicitly-declared `get` operation is not deleted, it is defined (that is, a function's body is generated and compiled) by the compiler if odr-used. The `hash_value` non-member operation `hash_combine` each concerned non-static data member of the object, in their initialization order. 
+If the implicitly-declared `get` operation is not deleted, it is defined (that is, a function's body is generated and compiled) by the compiler if odr-used. The `hash_value` non-member operation `hash_combine` each concerned non-static data member of the object, in their initialization order.
 
 
 
 # Alternative solutions
 
-Based on a future reflection library e.g. [N4428] or [N4451], we could define the tuple-like access instead of generating it (of course, for classes satisfying the tuple-like access generation requirements).  
+Based on a future reflection library (e.g. [N4428] or [N4451]), we could define the tuple-like access instead of generating it (of course, for classes satisfying the tuple-like access generation requirements).
 
 Next follows a incomplete implementation when inheritance is not considered.
 
@@ -248,7 +249,7 @@ namespace std {namespace experimental {namespace reflect { inline namespace v1 {
         //   no base classes (this is the restriction of the draft - no inheritance)
         class_base_classes<C>::size==0
         > {};
-        
+
     template <class C, class Enabler=void>
     struct tuple_size
     template <class C, class Enabler=enable_if_t<is_tuple_like_generation_enabled<C>{}> >
@@ -317,14 +318,14 @@ This proposal needs some compiler magic, either by generating directly the tuple
 
 # Open Questions
 
-The authors would like to have an answer to the following points if there is at all an interest in this proposal:
+The authors would like to have an answer to the following points if there is any interest at all in this proposal:
 
 * Do we want a default or a reflection solution?
 * Do we want a explicit conversions to `std::pair`/`std::tuple`?
 
 # Acknowledgments
 
-Thanks to all those that have commented the idea on the std-standard ML better helping to identify the constraints, in particular to Nicol Bolas and Matthew Woehlke. 
+Thanks to all those that have commented the idea on the std-standard ML better helping to identify the constraints, in particular to Nicol Bolas and Matthew Woehlke.
 
 # References
 
@@ -363,7 +364,7 @@ Thanks to all those that have commented the idea on the std-standard ML better h
     http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4428.pdf
 
 * [N4451] Static reflection
- 
+
     http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4451.pdf
 
 * [N4475] Default comparisons (R2)


### PR DESCRIPTION
Fix grammatical errors. Improve some phrasing. Consistently name papers in title case (even where the actual papers don't use title case in their titles) for improved readability.

Although a few of the phrasing changes are somewhat less than trivial, none should not substantively affect the proposal.

p.s. It looks like github's diff may be worse than useless. I recommend using `git diff --color-words`.
