### PR TITLE
Minor typos

### DIFF
--- a/doc/proposal/reflection/P0199R0.md
+++ b/doc/proposal/reflection/P0199R0.md
@@ -21,7 +21,8 @@
     </tr>
 </table>
 
-# Default Hash 
+
+# Default Hash 
 ==============
 
 **Abstract**
@@ -84,7 +85,7 @@ If Default comparison [N4475] is adopted, the `==` operator will be not needed a
 
 I propose to generate default versions for `hash_value` for simple classes when needed. If those defaults are unsuitable for a type, `=delete` them. If non-default of those operations are needed, define them (as always). If an operation is already declared, a default is not generated for it. This is exactly the way assignment and constructors work today and as comparison operators would work is [N4475] is adopted.
 
-Note that if `==` operator is defined by the user,  `has_value` default generation couldn't reflect the user decisions, and so it seems reasonable to don't provide such a generation. 
+Note that if `==` operator is defined by the user,  `hash_value` default generation couldn't reflect the user decisions, and so it seems reasonable to not provide such a generation. 
 
 The same rationale given in [N4475] applies `hash_value`. 
 
@@ -124,11 +125,11 @@ In addition to the common restrictions defined above, the following restricts th
 
 ## What is the definition of `hash_value`?
 
-The natural definition which combines, using `hash_combine`, each one of the data members seam to be a good candidate for the default. 
+The natural definition which combines, using `hash_combine`, each one of the data members seem to be a good candidate for the default. 
 
 ## When `hash_value` could be applied?
 
-The following restricts the generation of `has_value` for a class C
+The following restricts the generation of `hash_value` for a class C
 
 * has that operation defined or deleted before the first need for `hash_value` or
 * the `==` operator is user defined or cannot be generated, or
@@ -148,9 +149,9 @@ Mutable members are ignored for the generated implementations.
 
 # Design Rationale
 
-## Why to require that the default generation of `operator==` is applied?
+## Why require that the default generation of `operator==` is applied?
 
-The members use in the default generation for `hash_value` or the specialization of `is_uniquely_represented`  must be the same than the ones that are taken in account for the definition of the `==` operator. When the user defines the `==` operator, there is no evident way to ensure this constrain. This is why the default generation for `hash_value` and `is_uniquely_represented` is applied only when the generation of `==` is also applied.
+The members use in the default generation for `hash_value` or the specialization of `is_uniquely_represented`  must be the same than the ones that are taken in account for the definition of the `==` operator. When the user defines the `==` operator, there is no evident way to ensure this constrain. This is why the default generation for `hash_value` and `is_uniquely_represented` is applied only when the default generation of `==` is also applied.
 
 ## `is_uniquely_represented` specialization
 
@@ -158,7 +159,7 @@ We could let the user the responsibility to specialize, however the author suspe
 
 # Working paper wording
 
-This wording is very “drafty” and has not gone through expert review. It is intended to reflect the design decisions described above. 
+This wording is very "drafty" and has not gone through expert review. It is intended to reflect the design decisions described above. 
 
 The author was not aware of the new wording for Default comparison in [N4532]. There are a lot of there that should inspire the wording for this function.
 
@@ -335,5 +336,4 @@ Thanks to all those that have commented the idea on the std-proposals ML helping
 
 * [P0029R0] A Unified Proposal for Composable Hashing
 
-	http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0029r0.html
-
+    http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0029r0.html


### PR DESCRIPTION
Hello,

Some minor edits done by editing the file directly on GitHub.
When I look at it, the raw diff looks strange, but the rich diff looks good.
Feel free to take the edits that work for you if the commit is not right.

Kind regards,
JP

has_value => hash_value
seems reasonable to don't provide such => seems reasonable to not provide such
members seam to be a => members seem to be a
has_value => hash_value
Why to require => Why require
when the generation of `==` => when the default generation of `==`
Use basic double quotes around "drafty" matching the other double quotes.
replace the one tab at the end with 4 spaces
