### PR TITLE
Enable expected2 for GCC 8

### DIFF
--- a/include/experimental/fundamental/v3/expected2/expected.hpp
+++ b/include/experimental/fundamental/v3/expected2/expected.hpp
@@ -17,7 +17,7 @@
 #ifndef JASEL_EXPERIMENTAL_V3_EXPECTED_EXPECTED_HPP
 #define JASEL_EXPERIMENTAL_V3_EXPECTED_EXPECTED_HPP
 
-#if __cplusplus > 201402L && defined __clang__
+#if __cplusplus > 201402L && (defined __clang__ || __GNUC__ >= 8)
 
 #include <experimental/fundamental/v2/config.hpp>
 #include <experimental/fundamental/v3/result/helpers_detail.hpp>

--- a/test/expected2/trivial_expected_pass.cpp
+++ b/test/expected2/trivial_expected_pass.cpp
@@ -7,7 +7,7 @@
 // Copyright Vicente J. Botet Escriba 2018.
 
 #include <boost/detail/lightweight_test.hpp>
-#if __cplusplus > 201402L && defined __clang__
+#if __cplusplus > 201402L && (defined __clang__ || defined __GNUC__ >= 8)
 
 #include <experimental/expected2.hpp>
 #include <memory>


### PR DESCRIPTION
I tested this by compiling and running the tests manually. I didn't get the tests to run via CMake. (it compiled after setting `-Wno-unused-parameter` and removing some unnecessary semicolons in other files, but the expected2 tests didn't run).